### PR TITLE
save current model for SDXL (with --medvram-sdxl option)

### DIFF
--- a/scripts/model_mixer.py
+++ b/scripts/model_mixer.py
@@ -1301,7 +1301,17 @@ class ModelMixerScript(scripts.Script):
             if already_loaded is not None and already_loaded.title == checkpoint_info.title:
                 # model is already loaded
                 print(f"Loading {checkpoint_info.title} from loaded model...")
-                return {k: v.cpu() for k, v in shared.sd_model.state_dict().items()}
+                # save to cpu
+                sd_models.send_model_to_cpu(shared.sd_model)
+                sd_hijack.model_hijack.undo_hijack(shared.sd_model)
+
+                state_dict = shared.sd_model.state_dict()
+
+                # restore to gpu
+                sd_models.send_model_to_device(shared.sd_model)
+                sd_hijack.model_hijack.hijack(shared.sd_model)
+
+                return state_dict
 
             # get cached state_dict
             if shared.opts.sd_checkpoint_cache > 0:


### PR DESCRIPTION
With this fix, I've verified that the SDXL was saved correctly.

- [x] sdxl with `--medvram-sdxl` works
- [x] SD1.5 also works fine.
- [x] support  load already loaded or merged model from `shared.sd_model`
~~~diff
@@ -823,8 +823,16 @@ class ModelMixerScript(scripts.Script):
             metadata["sd_merge_models"] = json.dumps(metadata["sd_merge_models"])

             if shared.sd_model is not None:
-                print("load from shared.sd_model..")
+                print("Load state_dict from shared.sd_model..")
+                # save to cpu
+                sd_models.send_model_to_cpu(shared.sd_model)
+                sd_hijack.model_hijack.undo_hijack(shared.sd_model)
+
                 state_dict = shared.sd_model.state_dict()
+
+                # restore to gpu
+                sd_models.send_model_to_device(shared.sd_model)
+                sd_hijack.model_hijack.hijack(shared.sd_model)
             else:
                 print("No loaded model found")
                 return gr.update(value="No loaded model found")
~~~