### PR TITLE
Fast rebasin

### DIFF
--- a/scripts/model_mixer.py
+++ b/scripts/model_mixer.py
@@ -913,7 +913,7 @@ class ModelMixerScript(scripts.Script):
                 is_sdxl = gr.Checkbox(label="is SDXL", value=False, visible=True)
             with gr.Row():
                 calc_settings = gr.CheckboxGroup(label=f"Calculation options", info="Optional paramters for calculation if needed. e.g.) Rebasin",
-                    choices=[("Use GPU", "GPU"), ("Use CPU", "CPU")], value=["GPU"])
+                    choices=[("Use GPU", "GPU"), ("Use CPU", "CPU"), ("Fast Rebasin", "fastrebasin")], value=["GPU", "fastrebasin"])
 
 
             def update_basic_settings(basic_settings):
@@ -2850,6 +2850,7 @@ Direct Download: <a href="{s['downloadUrl']}" target="_blank">{s["filename"]} [{
 
         # check Rebasin mode
         if not isxl and "Rebasin" in calcmodes:
+            fullmatching = "fastrebasin" not in calc_settings
             print(" - Dynamic loading rebasin module...")
             load_module(os.path.join(scriptdir, "scripts", "rebasin", "weight_matching.py"))
             from scripts.rebasin.weight_matching import weight_matching, apply_permutation
@@ -2993,9 +2994,9 @@ Direct Download: <a href="{s['downloadUrl']}" target="_blank">{s["filename"]} [{
                 print("Rebasin calc...")
                 # rebasin mode
                 # Replace theta_0 with a permutated version using model A and B
-                first_permutation, y = weight_matching(permutation_spec, models["model_a"], theta_0, usefp16=usefp16, device=device)
+                first_permutation, y = weight_matching(permutation_spec, models["model_a"], theta_0, usefp16=usefp16, device=device, full=fullmatching)
                 theta_0 = apply_permutation(permutation_spec, first_permutation, theta_0)
-                #second_permutation, z = weight_matching(permutation_spec, theta_1, theta_0, usefp16=usefp16, device=device)
+                #second_permutation, z = weight_matching(permutation_spec, theta_1, theta_0, usefp16=usefp16, device=device, full=fullmatching)
                 #theta_3= apply_permutation(permutation_spec, second_permutation, theta_0)
                 shared.state.nextjob()
 

--- a/scripts/model_mixer.py
+++ b/scripts/model_mixer.py
@@ -2866,6 +2866,10 @@ Direct Download: <a href="{s['downloadUrl']}" target="_blank">{s["filename"]} [{
 
             print(" - Calulation device for Rebasin is ", device)
 
+            laplib = shared.opts.data.get("mm_laplib", "lap")
+            print(" - LAP library is", laplib)
+
+
         # set job_count
         save_jobcount = None
         if shared.state.job_count == -1:
@@ -2994,9 +2998,9 @@ Direct Download: <a href="{s['downloadUrl']}" target="_blank">{s["filename"]} [{
                 print("Rebasin calc...")
                 # rebasin mode
                 # Replace theta_0 with a permutated version using model A and B
-                first_permutation, y = weight_matching(permutation_spec, models["model_a"], theta_0, usefp16=usefp16, device=device, full=fullmatching)
+                first_permutation, y = weight_matching(permutation_spec, models["model_a"], theta_0, usefp16=usefp16, device=device, full=fullmatching, lap=laplib)
                 theta_0 = apply_permutation(permutation_spec, first_permutation, theta_0)
-                #second_permutation, z = weight_matching(permutation_spec, theta_1, theta_0, usefp16=usefp16, device=device, full=fullmatching)
+                #second_permutation, z = weight_matching(permutation_spec, theta_1, theta_0, usefp16=usefp16, device=device, full=fullmatching, lap=laplib)
                 #theta_3= apply_permutation(permutation_spec, second_permutation, theta_0)
                 shared.state.nextjob()
 
@@ -4393,6 +4397,17 @@ def on_ui_settings():
             label="Use UNet block partial update",
             component=gr.Checkbox,
             component_args={"interactive": True},
+            section=section,
+        ),
+    )
+
+    shared.opts.add_option(
+        "mm_laplib",
+        shared.OptionInfo(
+            default="lap",
+            label="Select LAP library for Rebasin calc. (Linear Assignment Problem maximum weight matching)",
+            component=gr.Radio,
+            component_args={"choices": ["lap", "lapjv", "scipy"]},
             section=section,
         ),
     )

--- a/scripts/rebasin/weight_matching.py
+++ b/scripts/rebasin/weight_matching.py
@@ -864,7 +864,7 @@ def weight_matching(ps: PermutationSpec, params_a, params_b, special_layers=None
               w_b = get_permuted_param(ps, perm, wk, params_b, except_axis=axis)
               w_a = torch.moveaxis(w_a, axis, 0).reshape((n, -1)).to(device)
               w_b = torch.moveaxis(w_b, axis, 0).reshape((n, -1)).T.to(device)
-              A += torch.matmul(w_a.half(), w_b.half())
+              A += torch.mm(w_a.half(), w_b.half())
 
           A = A.cpu()
           ci = lapfunc(A)
@@ -879,7 +879,7 @@ def weight_matching(ps: PermutationSpec, params_a, params_b, special_layers=None
 
           progress = progress or newL > oldL + 1e-12
 
-          perm[p] = torch.Tensor(ci)
+          perm[p] = torch.Tensor(ci).long()
         
       if not progress:
         break
@@ -911,7 +911,7 @@ def weight_matching(ps: PermutationSpec, params_a, params_b, special_layers=None
             w_b = get_permuted_param(ps, perm, wk, params_b, except_axis=axis)
             w_a = torch.moveaxis(w_a, axis, 0).reshape((n, -1)).to(device)
             w_b = torch.moveaxis(w_b, axis, 0).reshape((n, -1)).T.to(device)
-            A += torch.matmul(w_a.float(), w_b.float()).cpu()
+            A += torch.mm(w_a.float(), w_b.float()).cpu()
 
           ci = lapfunc(A)
 
@@ -925,7 +925,7 @@ def weight_matching(ps: PermutationSpec, params_a, params_b, special_layers=None
 
           progress = progress or newL > oldL + 1e-12
 
-          perm[p] = torch.Tensor(ci)
+          perm[p] = torch.Tensor(ci).long()
         
       if not progress:
         break

--- a/scripts/rebasin/weight_matching.py
+++ b/scripts/rebasin/weight_matching.py
@@ -832,7 +832,7 @@ def apply_permutation(ps: PermutationSpec, perm, params):
   """Apply a `perm` to `params`."""
   return {k: get_permuted_param(ps, perm, k, params) for k in params.keys() if "model_" not in k}
 
-def weight_matching(ps: PermutationSpec, params_a, params_b, special_layers=None, device="cpu", max_iter=3, init_perm=None, usefp16=False, usetqdm=True, full=False):
+def weight_matching(ps: PermutationSpec, params_a, params_b, special_layers=None, device="cpu", max_iter=3, init_perm=None, usefp16=False, usetqdm=True, full=False, lap="lap"):
   """Find a permutation of `params_b` to make them match `params_a`."""
   perm_sizes = {p: params_a[axes[0][0]].shape[axes[0][1]] for p, axes in ps.perm_to_axes.items() if axes[0][0] in params_b}
   perm = dict()
@@ -853,7 +853,7 @@ def weight_matching(ps: PermutationSpec, params_a, params_b, special_layers=None
   number = 0
   changed = []
 
-  lapfunc = default_lap()
+  lapfunc = default_lap(lap)
 
   if usefp16:
     for iteration in (desc:= tqdm(range(max_iter), position=1, bar_format='{desc}')):


### PR DESCRIPTION
- use `torch.mm()` instead `torch.matmul()`
- lapjv, lap support added (lap is the default. lap is fastest for me)
  - you can install `lap` or `lapjv` by `pip install lap` , `pip install lapjv` command ~~(currently, only "lap" will works)~~
- fast rebasin mode added.

originally, the `special_layers` for rebasin were `"P_bg358", "P_bg324", "P_bg337"`
https://github.com/ogkalu2/Merge-Stable-Diffusion-models-without-distortion/commit/c0dd03ec382899722f955fbb6aaa6d02bd5d390f#diff-ed17b6ad958b07d3f6300910b1c1e917c6995ec7770aff5fee28c95c3c5f0b2fL788
sd_meh also use the same https://github.com/s1dlx/meh/blob/main/sd_meh/rebasin.py#L2296

after some testing, we can confirm that the permutation groups whose weights change after maximum weight matching are limited to a subset of the permutations.
and an additional special layer `"P_bg371"` was found.

 - `P_bg324`: `.out.` unet
 - `P_bg358`: `.decoder.norm_out` vae
 - `P_bg337`: `.encoder.norm_out` vae
 - `P_bg371`: `.mlp.fc1`, `fc2` textencoder

now we can add "fast rebasin" mode.
